### PR TITLE
Add checks for macOS symlinks in /usr/local/bin

### DIFF
--- a/src/setup.jl
+++ b/src/setup.jl
@@ -27,6 +27,10 @@ end
         # try a few common directories
         if isfile("/usr/bin/stata")
             return "/usr/bin/stata"
+       elseif isfile("/usr/local/bin/stata-se")
+            return "/usr/local/bin/stata-se"
+       elseif isfile("/usr/local/bin/stata-mp")
+            return "/usr/local/bin/stata-mp"
         elseif isdir("/Applications/Stata/StataSE.app")
             appdir = "/Applications/Stata/StataSE.app"
         elseif isdir("/Applications/Stata/StataMP.app")


### PR DESCRIPTION
The Stata >13 SE/MP menu entry "Install Terminal Utility..." creates links to the binary in "/usr/local/bin" since update  November 12 2015 for Stata 13 and update October 29 2015 for Stata 14 and all subsequent versions.